### PR TITLE
feat: add KubeStellar Console to K8S-Cluster-Manage

### DIFF
--- a/items/K8S-Cluster-Manage/kubestellar-console.yaml
+++ b/items/K8S-Cluster-Manage/kubestellar-console.yaml
@@ -1,0 +1,5 @@
+kind: K8S-Cluster-Manage
+owner: kubestellar
+repo: console
+desc: '多集群 Kubernetes 仪表板，集成 AI 运维能力，支持跨集群实时可观测性，CNCF 沙箱项目。'
+desc_en: 'Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability across clusters. CNCF Sandbox project.'


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the K8S-Cluster-Manage category.

KubeStellar Console is an open-source multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability. It is a CNCF Sandbox project that supports managing workloads across edge and cloud clusters from a single pane of glass.

- **GitHub:** https://github.com/kubestellar/console
- **License:** Apache-2.0
- **CNCF Sandbox project**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 添加KubeStellar控制台支持，提供多集群Kubernetes管理仪表板，集成AI驱动的操作和实时可观测性功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->