### PR TITLE
Add go-exec-format-doctor to Dev-Tools

### DIFF
--- a/items/Dev-Tools/go-exec-format-doctor.yaml
+++ b/items/Dev-Tools/go-exec-format-doctor.yaml
@@ -1,0 +1,5 @@
+kind: Dev-Tools
+owner: soul-sol
+repo: go-exec-format-doctor
+desc: '离线诊断 ELF、Mach-O 和 PE 可执行文件的格式及架构不匹配，不执行目标文件且无需联网'
+desc_en: 'Diagnose ELF, Mach-O, and PE executable format and architecture mismatches locally without executing the target or using the network'


### PR DESCRIPTION
## Summary

- add `soul-sol/go-exec-format-doctor` to the `Dev-Tools` category
- include concise Chinese and English descriptions
- keep the generated README untouched, as required by the contribution guide

The listed project is a free, MIT-licensed, offline CLI for diagnosing ELF, Mach-O, and PE executable format and architecture mismatches without executing the inspected target. I maintain the listed project.

## Validation

- parsed the YAML and checked all five required fields
- confirmed the category matches the parent directory
- confirmed there is no duplicate repository entry
- confirmed the source repository is public, active, and MIT-licensed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `go-exec-format-doctor` 开发工具条目。
  - 补充工具类型、代码仓库及中文和英文简介，便于用户在工具目录中查看和识别。
- **文档**
  - 提供该工具的离线诊断能力说明及支持的可执行文件格式信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->